### PR TITLE
(+semver: breaking) Fix implementations of View and Source (especially View.Keys())

### DIFF
--- a/internal/generator/serviceTemplate.go
+++ b/internal/generator/serviceTemplate.go
@@ -50,12 +50,12 @@ func Register_{{ .ExportName }}(service *runner.Service, processor {{ .Package }
 
 {{ range .Sources }}
 func New_{{ .ExportName }}_Source(service *runner.Service) ({{ .Package }}.{{ .Name }}_Source, error) {
-	e, err := {{ .Package }}.New_{{ .Name }}_Source(service)
+	e, r, err := {{ .Package }}.New_{{ .Name }}_Source(service)
 	if err != nil {
 		return nil, err
 	}
 
-	err = service.RegisterRunner(e.Watch)
+	err = service.RegisterRunner(r)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to register runner with service")
 	}
@@ -71,12 +71,12 @@ func New_{{ .ExportName }}_Source(service *runner.Service) ({{ .Package }}.{{ .N
 
 {{ range .Views }}
 func New_{{ .ExportName }}_View(service *runner.Service) ({{ .Package }}.{{ .Name }}_View, error) {
-	v, err := {{ .Package }}.New_{{ .Name }}_View(service.Options())
+	v, r, err := {{ .Package }}.New_{{ .Name }}_View(service.Options())
 	if err != nil {
 		return nil, err
 	}
 
-	err = service.RegisterRunner(v.Watch)
+	err = service.RegisterRunner(r)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to register runner with service")
 	}

--- a/internal/generator/serviceTemplate_test.go
+++ b/internal/generator/serviceTemplate_test.go
@@ -51,12 +51,12 @@ func Register_Details_Enricher_Processor(service *runner.Service, processor deta
 }
 
 func New_Details_TestSerialDetails_Source(service *runner.Service) (details.TestSerialDetails_Source, error) {
-	e, err := details.New_TestSerialDetails_Source(service)
+	e, r, err := details.New_TestSerialDetails_Source(service)
 	if err != nil {
 		return nil, err
 	}
 
-	err = service.RegisterRunner(e.Watch)
+	err = service.RegisterRunner(r)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to register runner with service")
 	}
@@ -70,12 +70,12 @@ func New_Details_TestSerialDetails_Source(service *runner.Service) (details.Test
 }
 
 func New_Details_TestSerialDetailsEnriched_View(service *runner.Service) (details.TestSerialDetailsEnriched_View, error) {
-	v, err := details.New_TestSerialDetailsEnriched_View(service.Options())
+	v, r, err := details.New_TestSerialDetailsEnriched_View(service.Options())
 	if err != nil {
 		return nil, err
 	}
 
-	err = service.RegisterRunner(v.Watch)
+	err = service.RegisterRunner(r)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to register runner with service")
 	}

--- a/internal/generator/sourceTemplate.go
+++ b/internal/generator/sourceTemplate.go
@@ -16,12 +16,12 @@ package {{ .Package }}
 
 import (
 	"context"
-
+	
 	"github.com/burdiyan/kafkautil"
 	"github.com/lovoo/goka"
 	"github.com/pkg/errors"
-
 	"github.com/syncromatics/kafmesh/pkg/runner"
+	"golang.org/x/sync/errgroup"
 
 	"{{ .Import }}"
 )
@@ -62,7 +62,7 @@ func New_{{ .Name }}_Source(service *runner.Service) (*{{ .Name }}_Source_impl, 
 
 	codec, err := protoWrapper.Codec("{{ .TopicName }}", &{{ .MessageType }}{})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create codec")
+		return nil, nil, errors.Wrap(err, "failed to create codec")
 	}
 
 	emitter, err := goka.NewEmitter(brokers,
@@ -71,7 +71,7 @@ func New_{{ .Name }}_Source(service *runner.Service) (*{{ .Name }}_Source_impl, 
 		goka.WithEmitterHasher(kafkautil.MurmurHasher))
 
 	if err != nil {
-		return nil, errors.Wrap(err, "failed creating source")
+		return nil, nil, errors.Wrap(err, "failed creating source")
 	}
 
 	emitterCtx, emitterCancel := context.WithCancel(context.Background())

--- a/internal/generator/sourceTemplate.go
+++ b/internal/generator/sourceTemplate.go
@@ -33,6 +33,7 @@ type {{ .Name }}_Source interface {
 }
 
 type {{ .Name }}_Source_impl struct {
+	context.Context
 	emitter *runner.Emitter
 	metrics *runner.Metrics
 }
@@ -54,7 +55,7 @@ func (m *impl_{{ .Name }}_Source_Message) Value() interface{} {
 	return m.msg.Value
 }
 
-func New_{{ .Name }}_Source(service *runner.Service) (*{{ .Name }}_Source_impl, error) {
+func New_{{ .Name }}_Source(service *runner.Service) (*{{ .Name }}_Source_impl, func(context.Context) func() error, error) {
 	options := service.Options()
 	brokers := options.Brokers
 	protoWrapper := options.ProtoWrapper
@@ -73,14 +74,33 @@ func New_{{ .Name }}_Source(service *runner.Service) (*{{ .Name }}_Source_impl, 
 		return nil, errors.Wrap(err, "failed creating source")
 	}
 
-	return &{{ .Name }}_Source_impl{
-		emitter: runner.NewEmitter(emitter),
-		metrics: service.Metrics,
-	}, nil
-}
+	emitterCtx, emitterCancel := context.WithCancel(context.Background())
+	e := &{{ .Name }}_Source_impl{
+		emitterCtx,
+		runner.NewEmitter(emitter),
+		service.Metrics,
+	}
 
-func (e *{{ .Name }}_Source_impl) Watch(ctx context.Context) func() error {
-	return e.emitter.Watch(ctx)
+	return e, func(outerCtx context.Context) func() error {
+		cancelableCtx, cancel := context.WithCancel(outerCtx)
+		defer cancel()
+		grp, ctx := errgroup.WithContext(cancelableCtx)
+
+		grp.Go(func() error {
+			select {
+			case <-ctx.Done():
+				emitterCancel()
+				return nil
+			}
+		})
+		grp.Go(e.emitter.Watch(ctx))
+
+		select {
+		case <- ctx.Done():
+			err := grp.Wait()
+			return err
+		}
+	}, nil
 }
 
 func (e *{{ .Name }}_Source_impl) Emit(message {{ .Name }}_Source_Message) error {

--- a/internal/generator/sourceTemplate_test.go
+++ b/internal/generator/sourceTemplate_test.go
@@ -24,12 +24,12 @@ package details
 
 import (
 	"context"
-
+	
 	"github.com/burdiyan/kafkautil"
 	"github.com/lovoo/goka"
 	"github.com/pkg/errors"
-
 	"github.com/syncromatics/kafmesh/pkg/runner"
+	"golang.org/x/sync/errgroup"
 
 	"test/internal/kafmesh/models/testMesh/testSerial"
 )
@@ -70,7 +70,7 @@ func New_TestSerialDetails_Source(service *runner.Service) (*TestSerialDetails_S
 
 	codec, err := protoWrapper.Codec("testMesh.testSerial.details", &testSerial.Details{})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create codec")
+		return nil, nil, errors.Wrap(err, "failed to create codec")
 	}
 
 	emitter, err := goka.NewEmitter(brokers,
@@ -79,7 +79,7 @@ func New_TestSerialDetails_Source(service *runner.Service) (*TestSerialDetails_S
 		goka.WithEmitterHasher(kafkautil.MurmurHasher))
 
 	if err != nil {
-		return nil, errors.Wrap(err, "failed creating source")
+		return nil, nil, errors.Wrap(err, "failed creating source")
 	}
 
 	emitterCtx, emitterCancel := context.WithCancel(context.Background())

--- a/internal/generator/viewSinkTemplate.go
+++ b/internal/generator/viewSinkTemplate.go
@@ -18,18 +18,18 @@ package {{ .Package }}
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
-	"fmt"
 
 	"github.com/burdiyan/kafkautil"
 	"github.com/lovoo/goka"
 	"github.com/lovoo/goka/storage"
 	"github.com/pkg/errors"
+	"github.com/syncromatics/kafmesh/pkg/runner"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"golang.org/x/sync/errgroup"
-	"github.com/syncromatics/kafmesh/pkg/runner"
 
 	"{{ .Import }}"
 )

--- a/internal/generator/viewSinkTemplate_test.go
+++ b/internal/generator/viewSinkTemplate_test.go
@@ -24,18 +24,18 @@ package details
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
-	"fmt"
 
 	"github.com/burdiyan/kafkautil"
 	"github.com/lovoo/goka"
 	"github.com/lovoo/goka/storage"
 	"github.com/pkg/errors"
+	"github.com/syncromatics/kafmesh/pkg/runner"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"golang.org/x/sync/errgroup"
-	"github.com/syncromatics/kafmesh/pkg/runner"
 
 	"test/internal/kafmesh/models/testMesh/testId"
 )

--- a/internal/generator/viewSourceTemplate.go
+++ b/internal/generator/viewSourceTemplate.go
@@ -18,19 +18,18 @@ package {{ .Package }}
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
-	"fmt"
 
 	"github.com/burdiyan/kafkautil"
 	"github.com/lovoo/goka"
 	"github.com/lovoo/goka/storage"
 	"github.com/pkg/errors"
+	"github.com/syncromatics/kafmesh/pkg/runner"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/syncromatics/kafmesh/pkg/runner"
 
 	"{{ .Import }}"
 )

--- a/internal/generator/viewSourceTemplate_test.go
+++ b/internal/generator/viewSourceTemplate_test.go
@@ -24,19 +24,18 @@ package details
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
-	"fmt"
 
 	"github.com/burdiyan/kafkautil"
 	"github.com/lovoo/goka"
 	"github.com/lovoo/goka/storage"
 	"github.com/pkg/errors"
+	"github.com/syncromatics/kafmesh/pkg/runner"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"golang.org/x/sync/errgroup"
-
-	"github.com/syncromatics/kafmesh/pkg/runner"
 
 	"test/internal/kafmesh/models/testMesh/testId"
 )

--- a/internal/generator/viewSourceTemplate_test.go
+++ b/internal/generator/viewSourceTemplate_test.go
@@ -81,14 +81,12 @@ func Register_TestToDatabase_ViewSource(options runner.ServiceOptions, synchroni
 	}
 
 	builder := storage.BuilderWithOptions(path, opts)
-
 	view, err := goka.NewView(brokers,
 		goka.Table("testMesh.testId.test"),
 		codec,
 		goka.WithViewStorageBuilder(builder),
 		goka.WithViewHasher(kafkautil.MurmurHasher),
 	)
-
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating synchronizer view")
 	}
@@ -104,26 +102,26 @@ func Register_TestToDatabase_ViewSource(options runner.ServiceOptions, synchroni
 
 	emitter := runner.NewEmitter(e)
 
-	return func(ctx context.Context) func() error {
+	return func(outerCtx context.Context) func() error {
 		return func() error {
-			gctx, cancel := context.WithCancel(ctx)
-			grp, gctx := errgroup.WithContext(ctx)
+			cancelableCtx, cancel := context.WithCancel(outerCtx)
 			defer cancel()
+			grp, ctx := errgroup.WithContext(cancelableCtx)
 
 			timer := time.NewTimer(0)
 			grp.Go(func() error {
 				for {
 					select {
-					case <-gctx.Done():
+					case <-ctx.Done():
 						return nil
 					case <-timer.C:
 						select {
-						case <-gctx.Done():
+						case <-ctx.Done():
 							return nil
-						case <-view.WaitRecovered():
+						case <-view.WaitRunning():
 						}
 			
-						newContext, cancel := context.WithTimeout(gctx, syncTimeout)
+						newContext, cancel := context.WithTimeout(ctx, syncTimeout)
 						c := runner.NewProtoViewSourceJob(newContext, view, emitter)
 						cw := &contextWrap_TestToDatabase{newContext, c}
 						err := synchronizer.Sync(cw)
@@ -144,15 +142,13 @@ func Register_TestToDatabase_ViewSource(options runner.ServiceOptions, synchroni
 				}
 			})
 
-			grp.Go(emitter.Watch(gctx))
+			grp.Go(emitter.Watch(ctx))
 			grp.Go(func() error {
-				return view.Run(gctx)
+				return view.Run(ctx)
 			})
 
 			select {
 			case <- ctx.Done():
-				return nil
-			case <- gctx.Done():
 				err := grp.Wait()
 				return err
 			}

--- a/internal/generator/viewTemplate.go
+++ b/internal/generator/viewTemplate.go
@@ -23,9 +23,9 @@ import (
 	"github.com/lovoo/goka"
 	"github.com/lovoo/goka/storage"
 	"github.com/pkg/errors"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-
 	"github.com/syncromatics/kafmesh/pkg/runner"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"golang.org/x/sync/errgroup"
 
 	"{{ .Import }}"
 )
@@ -46,7 +46,7 @@ func New_{{ .Name }}_View(options runner.ServiceOptions) (*{{ .Name }}_View_impl
 
 	codec, err := protoWrapper.Codec("{{ .TopicName }}", &{{ .MessageType }}{})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create codec")
+		return nil, nil, errors.Wrap(err, "failed to create codec")
 	}
 
 	opts := &opt.Options{
@@ -58,7 +58,7 @@ func New_{{ .Name }}_View(options runner.ServiceOptions) (*{{ .Name }}_View_impl
 
 	err = os.MkdirAll(path, os.ModePerm)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create view db directory")
+		return nil, nil, errors.Wrap(err, "failed to create view db directory")
 	}
 
 	builder := storage.BuilderWithOptions(path, opts)
@@ -69,9 +69,8 @@ func New_{{ .Name }}_View(options runner.ServiceOptions) (*{{ .Name }}_View_impl
 		goka.WithViewStorageBuilder(builder),
 		goka.WithViewHasher(kafkautil.MurmurHasher),
 	)
-
 	if err != nil {
-		return nil, errors.Wrap(err, "failed creating view")
+		return nil, nil, errors.Wrap(err, "failed creating view")
 	}
 	
 	viewCtx, viewCancel := context.WithCancel(context.Background())

--- a/internal/generator/viewTemplate.go
+++ b/internal/generator/viewTemplate.go
@@ -31,7 +31,7 @@ import (
 )
 
 type {{ .Name }}_View interface {
-	Keys() []string
+	Keys() ([]string, error)
 	Get(key string) (*{{ .MessageType }}, error)
 }
 
@@ -84,8 +84,18 @@ func (v *{{ .Name }}_View_impl) Watch(ctx context.Context) func() error {
 	}
 }
 
-func (v *{{ .Name }}_View_impl) Keys() []string {
-	return v.Keys()
+func (v *{{ .Name }}_View_impl) Keys() ([]string, error) {
+	it, err := v.view.Iterator()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get iterator from view")
+	}
+	
+	keys := []string{}
+	for it.Next() {
+		keys = append(keys, it.Key())
+	}
+
+	return keys, nil
 }
 
 func (v *{{ .Name }}_View_impl) Get(key string) (*{{ .MessageType }}, error) {

--- a/internal/generator/viewTemplate.go
+++ b/internal/generator/viewTemplate.go
@@ -80,25 +80,27 @@ func New_{{ .Name }}_View(options runner.ServiceOptions) (*{{ .Name }}_View_impl
 	}
 
 	return v, func(outerCtx context.Context) func() error {
-		cancelableCtx, cancel := context.WithCancel(outerCtx)
-		defer cancel()
-		grp, ctx := errgroup.WithContext(cancelableCtx)
+		return func() error {
+			cancelableCtx, cancel := context.WithCancel(outerCtx)
+			defer cancel()
+			grp, ctx := errgroup.WithContext(cancelableCtx)
 
-		grp.Go(func() error {
+			grp.Go(func() error {
+				select {
+				case <-ctx.Done():
+					viewCancel()
+					return nil
+				}
+			})
+			grp.Go(func() error {
+				return v.view.Run(ctx)
+			})
+			
 			select {
-			case <-ctx.Done():
-				viewCancel()
-				return nil
+			case <- ctx.Done():
+				err := grp.Wait()
+				return err
 			}
-		})
-		grp.Go(func() error {
-			return v.view.Run(ctx)
-		})
-		
-		select {
-		case <- ctx.Done():
-			err := grp.Wait()
-			return err
 		}
 	}, nil
 }

--- a/internal/generator/viewTemplate.go
+++ b/internal/generator/viewTemplate.go
@@ -36,10 +36,11 @@ type {{ .Name }}_View interface {
 }
 
 type {{ .Name }}_View_impl struct {
+	context.Context
 	view *goka.View
 }
 
-func New_{{ .Name }}_View(options runner.ServiceOptions) (*{{ .Name }}_View_impl, error) {
+func New_{{ .Name }}_View(options runner.ServiceOptions) (*{{ .Name }}_View_impl, func(context.Context) func() error, error) {
 	brokers := options.Brokers
 	protoWrapper := options.ProtoWrapper
 
@@ -72,16 +73,35 @@ func New_{{ .Name }}_View(options runner.ServiceOptions) (*{{ .Name }}_View_impl
 	if err != nil {
 		return nil, errors.Wrap(err, "failed creating view")
 	}
-
-	return &{{ .Name }}_View_impl{
-		view: view,
-	}, nil
-}
-
-func (v *{{ .Name }}_View_impl) Watch(ctx context.Context) func() error {
-	return func() error {
-		return v.view.Run(ctx)
+	
+	viewCtx, viewCancel := context.WithCancel(context.Background())
+	v := &{{ .Name }}_View_impl{
+		viewCtx,
+		view,
 	}
+
+	return v, func(outerCtx context.Context) func() error {
+		cancelableCtx, cancel := context.WithCancel(outerCtx)
+		defer cancel()
+		grp, ctx := errgroup.WithContext(cancelableCtx)
+
+		grp.Go(func() error {
+			select {
+			case <-ctx.Done():
+				viewCancel()
+				return nil
+			}
+		})
+		grp.Go(func() error {
+			return v.view.Run(ctx)
+		})
+		
+		select {
+		case <- ctx.Done():
+			err := grp.Wait()
+			return err
+		}
+	}, nil
 }
 
 func (v *{{ .Name }}_View_impl) Keys() ([]string, error) {

--- a/internal/generator/viewTemplate.go
+++ b/internal/generator/viewTemplate.go
@@ -85,6 +85,12 @@ func (v *{{ .Name }}_View_impl) Watch(ctx context.Context) func() error {
 }
 
 func (v *{{ .Name }}_View_impl) Keys() ([]string, error) {
+	select {
+	case <-v.Done():
+		return nil, errors.New("context cancelled while waiting for partition to become running")
+	case <-v.view.WaitRunning():
+	}
+
 	it, err := v.view.Iterator()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get iterator from view")
@@ -99,6 +105,12 @@ func (v *{{ .Name }}_View_impl) Keys() ([]string, error) {
 }
 
 func (v *{{ .Name }}_View_impl) Get(key string) (*{{ .MessageType }}, error) {
+	select {
+	case <-v.Done():
+		return nil, errors.New("context cancelled while waiting for partition to become running")
+	case <-v.view.WaitRunning():
+	}
+
 	m, err := v.view.Get(key)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get value from view")

--- a/internal/generator/viewTemplate_test.go
+++ b/internal/generator/viewTemplate_test.go
@@ -39,7 +39,7 @@ import (
 )
 
 type TestSerialDetailsEnriched_View interface {
-	Keys() []string
+	Keys() ([]string, error)
 	Get(key string) (*testSerial.DetailsEnriched, error)
 }
 
@@ -92,8 +92,18 @@ func (v *TestSerialDetailsEnriched_View_impl) Watch(ctx context.Context) func() 
 	}
 }
 
-func (v *TestSerialDetailsEnriched_View_impl) Keys() []string {
-	return v.Keys()
+func (v *TestSerialDetailsEnriched_View_impl) Keys() ([]string, error) {
+	it, err := v.view.Iterator()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get iterator from view")
+	}
+	
+	keys := []string{}
+	for it.Next() {
+		keys = append(keys, it.Key())
+	}
+
+	return keys, nil
 }
 
 func (v *TestSerialDetailsEnriched_View_impl) Get(key string) (*testSerial.DetailsEnriched, error) {

--- a/internal/generator/viewTemplate_test.go
+++ b/internal/generator/viewTemplate_test.go
@@ -93,6 +93,12 @@ func (v *TestSerialDetailsEnriched_View_impl) Watch(ctx context.Context) func() 
 }
 
 func (v *TestSerialDetailsEnriched_View_impl) Keys() ([]string, error) {
+	select {
+	case <-v.Done():
+		return nil, errors.New("context cancelled while waiting for partition to become running")
+	case <-v.view.WaitRunning():
+	}
+
 	it, err := v.view.Iterator()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get iterator from view")
@@ -107,6 +113,12 @@ func (v *TestSerialDetailsEnriched_View_impl) Keys() ([]string, error) {
 }
 
 func (v *TestSerialDetailsEnriched_View_impl) Get(key string) (*testSerial.DetailsEnriched, error) {
+	select {
+	case <-v.Done():
+		return nil, errors.New("context cancelled while waiting for partition to become running")
+	case <-v.view.WaitRunning():
+	}
+
 	m, err := v.view.Get(key)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get value from view")

--- a/internal/generator/viewTemplate_test.go
+++ b/internal/generator/viewTemplate_test.go
@@ -31,9 +31,9 @@ import (
 	"github.com/lovoo/goka"
 	"github.com/lovoo/goka/storage"
 	"github.com/pkg/errors"
-	"github.com/syndtr/goleveldb/leveldb/opt"
-
 	"github.com/syncromatics/kafmesh/pkg/runner"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"golang.org/x/sync/errgroup"
 
 	"test/internal/kafmesh/models/testMesh/testSerial"
 )
@@ -54,7 +54,7 @@ func New_TestSerialDetailsEnriched_View(options runner.ServiceOptions) (*TestSer
 
 	codec, err := protoWrapper.Codec("testMesh.testSerial.detailsEnriched", &testSerial.DetailsEnriched{})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create codec")
+		return nil, nil, errors.Wrap(err, "failed to create codec")
 	}
 
 	opts := &opt.Options{
@@ -66,7 +66,7 @@ func New_TestSerialDetailsEnriched_View(options runner.ServiceOptions) (*TestSer
 
 	err = os.MkdirAll(path, os.ModePerm)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create view db directory")
+		return nil, nil, errors.Wrap(err, "failed to create view db directory")
 	}
 
 	builder := storage.BuilderWithOptions(path, opts)
@@ -77,9 +77,8 @@ func New_TestSerialDetailsEnriched_View(options runner.ServiceOptions) (*TestSer
 		goka.WithViewStorageBuilder(builder),
 		goka.WithViewHasher(kafkautil.MurmurHasher),
 	)
-
 	if err != nil {
-		return nil, errors.Wrap(err, "failed creating view")
+		return nil, nil, errors.Wrap(err, "failed creating view")
 	}
 	
 	viewCtx, viewCancel := context.WithCancel(context.Background())


### PR DESCRIPTION
This requires a change to the return value from Keys() in order to pass through a possible error from retrieving the iterator from the view.

closes #36
closes EN-7623