### PR TITLE
(+semver: fix) Generate consistently-unique sink names in discover.km.go

### DIFF
--- a/internal/generator/discoverTemplate.go
+++ b/internal/generator/discoverTemplate.go
@@ -426,7 +426,7 @@ func generateDiscover(writer io.Writer, service *models.Service, components []*m
 					Topic:   sink.ToTopicName(service),
 					Type:    t,
 				},
-				MethodName:  fmt.Sprintf("%s_%s_Sink", component.ToSafeName(), sink.ToSafeMessageTypeName()),
+				MethodName:  fmt.Sprintf("%s_%s_Sink", component.ToSafeName(), sink.ToSafeName()),
 				Name:        sink.Name,
 				Description: sink.Description,
 			})

--- a/internal/generator/serviceTemplate.go
+++ b/internal/generator/serviceTemplate.go
@@ -251,7 +251,7 @@ func buildServiceOptions(service *models.Service, components []*models.Component
 		for _, s := range c.Sinks {
 			proc := serviceSink{
 				Package:    c.Name,
-				ExportName: fmt.Sprintf("%s_%s", c.ToSafeName(), s.ToSafeMessageTypeName()),
+				ExportName: fmt.Sprintf("%s_%s", c.ToSafeName(), s.ToSafeName()),
 				Name:       s.ToSafeName(),
 			}
 			options.Sinks = append(options.Sinks, proc)

--- a/internal/generator/serviceTemplate_test.go
+++ b/internal/generator/serviceTemplate_test.go
@@ -99,7 +99,7 @@ func Register_EnrichedDataPostgres_Sink(service *runner.Service, sink details.En
 		return errors.Wrap(err, "failed to register runner with service")
 	}
 
-	err = discover_Details_TestSerialDetailsEnriched_Sink(service)
+	err = discover_Details_EnrichedDataPostgres_Sink(service)
 	if err != nil {
 		return errors.Wrap(err, "failed to register with discovery")
 	}


### PR DESCRIPTION
Updated `discoverTemplate.go` to use the same ToSafeName func that `sinkTemplate.go` uses for generating sink func names.

Closes #39